### PR TITLE
Make hubot-tell work with Hipchat

### DIFF
--- a/src/tell.coffee
+++ b/src/tell.coffee
@@ -41,7 +41,7 @@ module.exports = (robot) ->
     recipients = msg.match[2].split(',').filter((x) -> x?.length)
     message = msg.match[3]
 
-    room = msg.message.user.room
+    room = if msg.message.user.reply_to then msg.message.user.reply_to else msg.message.user.room
     tellmessage = [msg.message.user.name, new Date(), message]
     if not localstorage[room]?
       localstorage[room] = {}


### PR DESCRIPTION
In Hipchat, the `msg.message.user.room` value referenced in `robot.enter` is different to the `msg.message.user.room` value referenced in `robot.respond`.

`robot.respond` receives a packet like:

```
{ reply_to: '12345_stuff@conf.hipchat.com', room: 'stuff' }
```

whereas `robot.enter` receives just the '12345_stuff@conf.hipchat.com' style room name.

This PR makes the script store against the '12345_stuff@conf.hipchat.com' style room name.
