### PR TITLE
tell: send replies on room entry AND next time leaves a message

### DIFF
--- a/src/tell.coffee
+++ b/src/tell.coffee
@@ -77,6 +77,7 @@ module.exports = (robot) ->
     if not localstorage[room]?
       localstorage[room] = {}
     for recipient in recipients
+      robot.logger.debug "storing message in #{room} for #{recipient}"
       if localstorage[room][recipient]?
         localstorage[room][recipient].push(tellmessage)
       else

--- a/src/tell.coffee
+++ b/src/tell.coffee
@@ -35,20 +35,24 @@ check_messages = (robot, room, username) ->
   localstorage = JSON.parse(robot.brain.get 'hubot-tell') or {}
   tellmessages = []
 
+  robot.logger.debug "hubot-tell: checking msgs in #{room} for #{username}"
+
   if localstorage[room]?
-      for recipient, message of localstorage[room]
-        # Check if the recipient matches username
-        if username.match new RegExp("^#{recipient}", "i")
-          tellmessage = "#{username}: "
-          for message in localstorage[room][recipient]
-            # Also check that we have successfully loaded timeago
-            if config.relativeTime && timeago?
-              timestr = timeago(message[1])
-            else
-              timestr = "at #{message[1].toLocaleString()}"
-            tellmessage += "#{message[0]} said #{timestr}: #{message[2]}\r\n"
-          delete localstorage[room][recipient]
+    for recipient, message of localstorage[room]
+      # Check if the recipient matches username
+      if username.match new RegExp("^#{recipient}", "i")
+        tellmessage = "#{username}: "
+        for message in localstorage[room][recipient]
+          # Also check that we have successfully loaded timeago
+          if config.relativeTime && timeago?
+            timestr = timeago(message[1])
+          else
+            timestr = "at #{message[1].toLocaleString()}"
+          tellmessage += "#{message[0]} said #{timestr}: #{message[2]}\r\n"
           tellmessages.push tellmessage
+        delete localstorage[room][recipient]
+
+  robot.logger.debug "hubot-tell: there are #{tellmessages.length} messages for #{username}"
 
   robot.brain.set 'hubot-tell', JSON.stringify(localstorage)
   robot.brain.save()


### PR DESCRIPTION
Hey @lorenzhs, @patcon, & co!

We're using Slack and we rarely actually leave & re-enter rooms. We'd like the ability to have hubot send a user the messages others have left for them next time the user leaves any messages in the channel. Some users get so many notifications (common name, manager with many reports, etc) that it becomes difficult for them to parse through all the notifications they get. They get buried easily.

This change listens for any activity and checks if the user has messages. If the user has messages, it writes them out! It essentially just mirrors the activity for entering but based on arbitrary messages.
