### PR TITLE
tell: allow username to be proceeded with @

### DIFF
--- a/src/tell.coffee
+++ b/src/tell.coffee
@@ -32,7 +32,7 @@ module.exports = (robot) ->
   commands = ['tell'].concat(config.aliases)
   commands = commands.join('|')
 
-  REGEX = ///(#{commands})\s+([\w,.-]+):?\s+(.*)///i
+  REGEX = ///(#{commands})\s+@?([\w,.-]+):?\s+(.*)///i
 
   robot.respond REGEX, (msg) ->
     localstorage = JSON.parse(robot.brain.get 'hubot-tell') or {}


### PR DESCRIPTION
This allows us to do either:

``` text
hubot tell parkr Hi!
```

or:

``` text
hubot tell @parkr Hi!
```

:)

/cc @lorenzhs @patcon @technicalpickles 
